### PR TITLE
Detect availability of __format_arg__ attribute using __has_attribute

### DIFF
--- a/libintl.h
+++ b/libintl.h
@@ -33,7 +33,13 @@
 # define __GNU_GETTEXT_SUPPORTED_REVISION
 #endif
 
-#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
+#if defined(__has_attribute)
+# define PROXY_LIBINTL_HAS_GNUC_FORMAT __has_attribute(__format_arg__)
+#else
+# define PROXY_LIBINTL_HAS_GNUC_FORMAT (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))
+#endif
+
+#if PROXY_LIBINTL_HAS_GNUC_FORMAT
 # define PROXY_LIBINTL_GNUC_FORMAT(arg_idx) __attribute__((__format_arg__(arg_idx)))
 #else
 # define PROXY_LIBINTL_GNUC_FORMAT(arg_idx)


### PR DESCRIPTION
clang-cl supports `__format_arg__`, but doesn't define `__GNUC__`.

GCC also supports `__has_attribute` since version 5.0.

https://clang.llvm.org/docs/LanguageExtensions.html#has-attribute
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html

I'm adding attribute support on clang-cl to GLib https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2043
proxy-libintl should use `__format_arg__` on clang-cl too, otherwise there will be a lot of warnings like this:

```
[738/1067] Compiling C object gio/tests/gdbus-daemon.exe.p/gdbus-daemon.c.obj
../gio/tests/gdbus-daemon.c(42,19): warning: format string is not a string literal (potentially insecure) [-Wformat-security]
      g_printerr (_("Wrong args\n"));
                  ^~~~~~~~~~~~~~~~~
..\glib/gi18n.h(26,20): note: expanded from macro '_'
#define  _(String) gettext (String)
                   ^~~~~~~~~~~~~~~~
..\subprojects\proxy-libintl\libintl.h(35,17): note: expanded from macro 'gettext'
#define gettext g_libintl_gettext
                ^
../gio/tests/gdbus-daemon.c(42,19): note: treat the string as an argument to avoid this
      g_printerr (_("Wrong args\n"));
                  ^
                  "%s",
..\glib/gi18n.h(26,20): note: expanded from macro '_'
#define  _(String) gettext (String)
                   ^
..\subprojects\proxy-libintl\libintl.h(35,17): note: expanded from macro 'gettext'
#define gettext g_libintl_gettext
                ^
```