### PR TITLE
Set G_INTL_STATIC_COMPILATION when making a static library

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ will also get exported from the libfoo DLL. This is definitely not
 what you want. It might then lead to other DLLs higher up in the
 dependency stack to import the libintl functions from the libfoo DLL.
 
-To avoid this, use the --exluce-libs ld flag, i.e. pass
+To avoid this, use the --exclude-libs ld flag, i.e. pass
 -Wl,--exclude-libs=libintl.a in your LDFLAGS when building
 libfoo. Unfortunately there is no __declspec(nodllexport)...
 

--- a/meson.build
+++ b/meson.build
@@ -14,5 +14,11 @@ intl_lib = library('intl',
   darwin_versions : ['10', '10.5'],
   install : true)
 
+c_args = []
+if get_option('default_library') == 'static'
+  c_args += ['-DG_INTL_STATIC_COMPILATION']
+endif
+
 intl_dep = declare_dependency(link_with : intl_lib,
+  compile_args: c_args,
   include_directories : include_directories('.'))


### PR DESCRIPTION
When doing static builds of glib on Windows, libintl (in this case, `proxy-libintl`) is typically built from source using a Meson subproject.

The `G_INTL_STATIC_COMPILATION` define needs to be set when linking statically against `proxy-libintl`. It can either be set in glib's own `meson.build`, or directly in `proxy-libintl`'s `meson.build`, if my understanding is correct.

This is useful for PRs/MRs like https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1655/ which try to get static msvc glib builds on Windows to work out of the box.