### PR TITLE
Fix Windows static build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,10 @@ project('proxy-libintl', 'c',
                       'c_std=gnu99',
                       'buildtype=debugoptimized' ])
 
+if get_option('default_library') == 'static'
+  add_project_arguments('-DG_INTL_STATIC_COMPILATION', language : 'c')
+endif
+
 install_headers('libintl.h')
 
 intl_lib = library('intl',


### PR DESCRIPTION
On Windows, static compilation needs G_INTL_STATIC_COMPILATION
to be also defined during compilation. Else functions are exported with
__declspec(dllexport) which causes issues when importing symbols during
linkage with the static library.