### PR TITLE
Add wbindtextdomain

### DIFF
--- a/libintl.c
+++ b/libintl.c
@@ -236,19 +236,25 @@ setup (void)
   if (!beenhere)
     {
 #if !STUB_ONLY
-#if defined(_WIN64)
-      /* On 64-bit Windows we have let libtool choose the default name
-       * for the DLL, as we don't need the intl.dll name for backward
-       * compatibility
-       */
-      HMODULE intl_dll = LoadLibrary ("libintl-8.dll");
-#  elif defined( _WIN32)
-      HMODULE intl_dll = LoadLibrary ("intl.dll");
-#  elif defined(__APPLE__) && defined(__MACH__)
-      HMODULE intl_dll = dlopen ("libintl.dylib", RTLD_LAZY);
+# if defined(_WIN32)
+#  if !defined (_MSC_VER)
+      HMODULE intl_dll = LoadLibraryW (L"libintl-8.dll");
+#   if defined (_M_IX86)
+      /* Also try without libtool naming scheme for
+       * backward compatibility. That's only needed
+       * on x86 */
+      if (intl_dll == NULL) {
+        intl_dll = LoadLibraryW (L"intl.dll");
+      }
+#   endif
 #  else
-      HMODULE intl_dll = dlopen ("libintl.so", RTLD_LAZY);
+      HMODULE intl_dll = LoadLibraryW (L"intl.dll");
 #  endif
+# elif defined(__APPLE__) && defined(__MACH__)
+      HMODULE intl_dll = dlopen ("libintl.dylib", RTLD_LAZY);
+# else
+      HMODULE intl_dll = dlopen ("libintl.so", RTLD_LAZY);
+# endif
 #else  /* !STUB_ONLY */
       HMODULE intl_dll = NULL;
 #endif  /* STUB_ONLY */

--- a/libintl.h
+++ b/libintl.h
@@ -22,6 +22,10 @@
 
 #include <locale.h>
 
+#ifdef _WIN32
+#include <stddef.h> /* for wchar_t */
+#endif
+
 #ifndef LC_MESSAGES
 # define LC_MESSAGES 1729       /* Use same value as in GNU gettext */
 #endif
@@ -54,6 +58,10 @@
 #define textdomain g_libintl_textdomain
 #define bindtextdomain g_libintl_bindtextdomain
 #define bind_textdomain_codeset g_libintl_bind_textdomain_codeset
+
+#ifdef _WIN32
+#define wbindtextdomain g_libintl_wbindtextdomain
+#endif
 
 /* Define G_INTL_STATIC_COMPILATION to link statically */
 #if defined(_WIN32) && !defined(G_INTL_STATIC_COMPILATION)
@@ -102,6 +110,11 @@ G_INTL_EXPORT char *g_libintl_bindtextdomain (const char *domainname,
 
 G_INTL_EXPORT char *g_libintl_bind_textdomain_codeset (const char *domainname,
 						const char *codeset);
+
+#ifdef _WIN32
+G_INTL_EXPORT wchar_t *g_libintl_wbindtextdomain (const char *domainname,
+                                                  const wchar_t *wdirname);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The first commit adds wbindtextdomain, which was added to GNU gettext in version 0.21. wbindtextdomain is only available on Windows.

The second commit changes the expected library names to what's more common these days. For example, GNU libintl on 32bit architectures is named libintl-8.dll, not intl.dll:
* https://packages.msys2.org/package/mingw-w64-i686-gettext?repo=mingw32
* https://packages.msys2.org/package/mingw-w64-clang-i686-gettext?repo=clang32