### PR TITLE
Explicitly require Meson 0.48+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('proxy-libintl', 'c',
   version : '1',
-  meson_version : '>= 0.46.0',
+  meson_version : '>= 0.48.0',
   default_options : [ 'warning_level=1',
                       'c_std=gnu99',
                       'buildtype=debugoptimized' ])


### PR DESCRIPTION
Meson 1.3.0 complains about darwin_versions if Meson older than 0.48 is allowed:

    WARNING: Project specifies a minimum meson_version '>= 0.46.0' but
             uses features which were added in newer versions:
     * 0.48.0: {'darwin_versions arg in library'}