### PR TITLE
Drop `c_std=gnu99` to avoid Meson deprecation warning

### DIFF
--- a/libintl.c
+++ b/libintl.c
@@ -21,6 +21,7 @@
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
 #else
+#  define _POSIX_C_SOURCE 200809L
 #  include <stddef.h>
 #  if !STUB_ONLY
 #    include <dlfcn.h>

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('proxy-libintl', 'c',
   version : '1',
   meson_version : '>= 0.48.0',
   default_options : [ 'warning_level=1',
-                      'c_std=gnu99',
+                      'c_std=c99',
                       'buildtype=debugoptimized' ])
 
 if get_option('default_library') == 'static'


### PR DESCRIPTION
Meson &ge; 1.3.0 complains about `c_std=gnu99` when building with MSVC:

    DEPRECATION: None of the values ['gnu99'] are supported by the c compiler.
    However, the deprecated gnu99 std currently falls back to c99.
    This will be an error in the future.
    If the project supports both GNU and MSVC compilers, a value such as
    "c_std=gnu11,c11" specifies that GNU is prefered but it can safely fallback to plain c11.

This breaks CI for projects that embed proxy-libintl as a subproject and build with `--fatal-meson-warnings`.

We can't trivially fix this with `c_std=gnu99,c99`, since that syntax isn't supported by older Meson versions and we probably don't want to require Meson 1.3.0+.  Instead, switch to plain C99, and define `_POSIX_C_SOURCE` so we still have access to the needed function prototypes.